### PR TITLE
Added fixes for multi story fetch queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Storyblok Swift SDK - 0.1.2
+# Storyblok Swift SDK - 0.1.5
 
 [![Version](https://img.shields.io/cocoapods/v/RXSStoryblokClient.svg?style=flat)](https://cocoapods.org/pods/RXSStoryblokClient)
 [![License](https://img.shields.io/cocoapods/l/RXSStoryblokClient.svg?style=flat)](https://cocoapods.org/pods/RXSStoryblokClient)
@@ -7,6 +7,9 @@
 ## TL;DR
 This is a Swift SDK/Wrapper around the Storyblok Delivery API and the Storyblok Management API. As of now, only Story fetching, creation and deletion is supported. Additionally there is are Utility and Model classes for resolving RichText Objects from Storyblok (As of now there is only an Implementation for transforming the object to an HTML String)
 
+### Version 0.1.5
+* Fixed cocoapods source files path
+* Fixed Multi story parameters fix (when searching for slugs or uuids)
 ### Version 0.1.2
 * Added a `SingleStory` struct so it processes correctly single stories.
 * Fixed the single story fetch methods so they fetch properly even when no custom `dataConnection` is configured.

--- a/RXSStoryblokClient.podspec
+++ b/RXSStoryblokClient.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'RXSStoryblokClient'
-  s.version          = '0.1.4'
+  s.version          = '0.1.5'
   s.summary          = 'A lightweight pure Swift SDK for the Storyblok Content Delivery and Management APIs'
 
 # This description is used to generate tags and improve search results.
@@ -21,11 +21,11 @@ Pod::Spec.new do |s|
   'This is a Swift SDK/Wrapper around the Storyblok Delivery API and the Storyblok Management API. The purpose of this Pod is to make using said APIs easier, quicker and more readable.'
                        DESC
 
-  s.homepage         = 'https://github.com/regiolix-solutions/storyblok-swift-sdk'
+  s.homepage         = 'https://github.com/Mindera/storyblok-swift-sdk'
   # s.screenshots     = 'www.example.com/screenshots_1', 'www.example.com/screenshots_2'
   s.license          = { :type => 'MIT', :file => 'LICENSE' }
   s.author           = { 'Medweschek Michael' => 'michael@regiolix.at' }
-  s.source           = { :git => 'https://github.com/regiolix-solutions/storyblok-swift-sdk.git', :tag => '0.1.4' }
+  s.source           = { :git => 'https://github.com/Mindera/storyblok-swift-sdk.git', :tag => '0.1.5' }
   # s.social_media_url = 'https://twitter.com/<TWITTER_USERNAME>'
 
   s.ios.deployment_target = '13.0'

--- a/Sources/RXSStoryblokClient/Classes/Queries/StoryblokQuery.swift
+++ b/Sources/RXSStoryblokClient/Classes/Queries/StoryblokQuery.swift
@@ -47,27 +47,27 @@ public class StoryblokQuery: NSObject{
             dynamicDescription.append(contentsOf: "&starts_with=\(startsWith)")
         }
         
-        if let byUUIDs = byUUIDs {
+        if let byUUIDs = byUUIDs?.map({String($0.uuidString.lowercased())}).joined(separator: ",") {
             dynamicDescription.append(contentsOf: "&by_uuids=\(byUUIDs)")
         }
         
-        if let bySlugs = bySlugs {
+        if let bySlugs = bySlugs?.joined(separator: ",") {
             dynamicDescription.append(contentsOf: "&by_slugs=\(bySlugs)")
         }
         
-        if let excludingSlugs = excludingSlugs {
+        if let excludingSlugs = excludingSlugs?.joined(separator: ",") {
             dynamicDescription.append(contentsOf: "&excluding_slugs=\(excludingSlugs)")
         }
         
-        if let byUUIDsOrdered = byUUIDsOrdered {
+        if let byUUIDsOrdered = byUUIDsOrdered?.map({String($0.uuidString.lowercased())}).joined(separator: ",") {
             dynamicDescription.append(contentsOf: "&by_uuids_ordered=\(byUUIDsOrdered)")
         }
         
-        if let excludingIds = excludingIds {
+        if let excludingIds = excludingIds?.map({String($0)}).joined(separator: ",") {
             dynamicDescription.append(contentsOf: "&excluding_ids=\(excludingIds)")
         }
         
-        if let excludingFields = excludingFields {
+        if let excludingFields = excludingFields?.joined(separator: ",") {
             dynamicDescription.append(contentsOf: "&excluding_fields=\(excludingFields)")
         }
         


### PR DESCRIPTION
Before this PR:

If you searched for 2 slugs (in example: "homepage/test" and "homepage/default"), the slugs would be added to the query as:
`&by_slugs=["homepage/test", "homepage/default]`
which is not correct according to the Storyblok API docs.

So made some changes so that the query is actually added in as:
`&by_slugs=homepage/test,homepage/default`

Made these changes to the queries:
- searching by Slugs
- searching by UUIDs
- searching by ordered UUIDs
- searching by excluding slugs
- searching by excluding fields
- searching by excluding IDs