### PR TITLE
Fix StoryVersion query

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Storyblok Swift SDK - 0.1.9
+# Storyblok Swift SDK - 0.1.10
 
 [![Version](https://img.shields.io/cocoapods/v/RXSStoryblokClient.svg?style=flat)](https://cocoapods.org/pods/RXSStoryblokClient)
 [![License](https://img.shields.io/cocoapods/l/RXSStoryblokClient.svg?style=flat)](https://cocoapods.org/pods/RXSStoryblokClient)
@@ -7,6 +7,8 @@
 ## TL;DR
 This is a Swift SDK/Wrapper around the Storyblok Delivery API and the Storyblok Management API. As of now, only Story fetching, creation and deletion is supported. Additionally there is are Utility and Model classes for resolving RichText Objects from Storyblok (As of now there is only an Implementation for transforming the object to an HTML String)
 
+### Version 0.1.10
+* Fixed `startDataTaskWithCheckedThrowingContinuation` method on `RXSDataConnection` class not calling `resume` method on session dataTask to trigger the request.
 ### Version 0.1.9
 * Fixed StoryVersion query which was passing the query as 'Draft'/'Published' instead of 'draft'/'published' as is required by the Storyblok API.
 ### Version 0.1.7

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Storyblok Swift SDK - 0.1.8
+# Storyblok Swift SDK - 0.1.9
 
 [![Version](https://img.shields.io/cocoapods/v/RXSStoryblokClient.svg?style=flat)](https://cocoapods.org/pods/RXSStoryblokClient)
 [![License](https://img.shields.io/cocoapods/l/RXSStoryblokClient.svg?style=flat)](https://cocoapods.org/pods/RXSStoryblokClient)
@@ -7,6 +7,8 @@
 ## TL;DR
 This is a Swift SDK/Wrapper around the Storyblok Delivery API and the Storyblok Management API. As of now, only Story fetching, creation and deletion is supported. Additionally there is are Utility and Model classes for resolving RichText Objects from Storyblok (As of now there is only an Implementation for transforming the object to an HTML String)
 
+### Version 0.1.9
+* Fixed StoryVersion query which was passing the query as 'Draft'/'Published' instead of 'draft'/'published' as is required by the Storyblok API.
 ### Version 0.1.7
 * Queries with date related parameters weren't sending the date according to Storyblok API specs. Date queries are properly formatted now.
 ### Version 0.1.5

--- a/RXSStoryblokClient.podspec
+++ b/RXSStoryblokClient.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'RXSStoryblokClient'
-  s.version          = '0.1.9'
+  s.version          = '0.1.10'
   s.summary          = 'A lightweight pure Swift SDK for the Storyblok Content Delivery and Management APIs'
 
 # This description is used to generate tags and improve search results.

--- a/RXSStoryblokClient.podspec
+++ b/RXSStoryblokClient.podspec
@@ -25,7 +25,7 @@ Pod::Spec.new do |s|
   # s.screenshots     = 'www.example.com/screenshots_1', 'www.example.com/screenshots_2'
   s.license          = { :type => 'MIT', :file => 'LICENSE' }
   s.author           = { 'Medweschek Michael' => 'michael@regiolix.at' }
-  s.source           = { :git => 'https://github.com/Mindera/storyblok-swift-sdk.git', :tag => '0.1.9' }
+  s.source           = { :git => 'https://github.com/Mindera/storyblok-swift-sdk.git', :tag => '0.1.10' }
   # s.social_media_url = 'https://twitter.com/<TWITTER_USERNAME>'
 
   s.ios.deployment_target = '13.0'

--- a/RXSStoryblokClient.podspec
+++ b/RXSStoryblokClient.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'RXSStoryblokClient'
-  s.version          = '0.1.8'
+  s.version          = '0.1.9'
   s.summary          = 'A lightweight pure Swift SDK for the Storyblok Content Delivery and Management APIs'
 
 # This description is used to generate tags and improve search results.
@@ -21,11 +21,11 @@ Pod::Spec.new do |s|
   'This is a Swift SDK/Wrapper around the Storyblok Delivery API and the Storyblok Management API. The purpose of this Pod is to make using said APIs easier, quicker and more readable.'
                        DESC
 
-  s.homepage         = 'https://github.com/regiolix-solutions/storyblok-swift-sdk'
+  s.homepage         = 'https://github.com/Mindera/storyblok-swift-sdk'
   # s.screenshots     = 'www.example.com/screenshots_1', 'www.example.com/screenshots_2'
   s.license          = { :type => 'MIT', :file => 'LICENSE' }
   s.author           = { 'Medweschek Michael' => 'michael@regiolix.at' }
-  s.source           = { :git => 'https://github.com/regiolix-solutions/storyblok-swift-sdk.git', :tag => '0.1.8' }
+  s.source           = { :git => 'https://github.com/Mindera/storyblok-swift-sdk.git', :tag => '0.1.9' }
   # s.social_media_url = 'https://twitter.com/<TWITTER_USERNAME>'
 
   s.ios.deployment_target = '13.0'

--- a/Sources/RXSStoryblokClient/Classes/DataConnection/RXSDataConnection.swift
+++ b/Sources/RXSStoryblokClient/Classes/DataConnection/RXSDataConnection.swift
@@ -122,7 +122,7 @@ public class RXSDataConnection: DataConnection{
             }else{
                 continuation.resume(with: .success(nil))
             }
-        }
+        }.resume()
     }
 }
 

--- a/Sources/RXSStoryblokClient/Classes/Queries/StoryblokQuery.swift
+++ b/Sources/RXSStoryblokClient/Classes/Queries/StoryblokQuery.swift
@@ -107,7 +107,7 @@ public class StoryblokQuery: NSObject{
             dynamicDescription.append(contentsOf: "&per_page=\(perPage)")
         }
         
-        if let version = version {
+        if let version = version?.rawValue {
             dynamicDescription.append(contentsOf: "&version=\(version)")
         }
         


### PR DESCRIPTION
Fixed StoryVersion query, as Storyblok API requires that the path param for the version is sent as either `draft` or `published`, but `Draft` or `Published` were being sent instead.